### PR TITLE
Add time info for items in STILT queue

### DIFF
--- a/src/main/js/worker/components/MapView.jsx
+++ b/src/main/js/worker/components/MapView.jsx
@@ -189,7 +189,7 @@ const JobList = props => props.jobs.length
 const JobLabel = props => {
 	const job = props.job;
 	const lbl = {
-		txt: "Site '" + job.siteId + "'",
+		txt: `Site '${job.siteId}' (${job.start} - ${job.stop})`,
 		cls: "bg-dark bg-opacity-50 fw-bold text-white",
 		title: `Site Id: ${job.siteId}
 Latitude: ${job.lat}


### PR DESCRIPTION
Dear maintainers,

thank you for this very interesting tool!

When using it, I found my job stuck in the queue for quite some time. The main problem about that is that I couldn't estimate, when my job would be finished, because the queue only shows the site ids, not the start and end dates (see image below).

After inspecting the source code, I saw that I need to hover (not click) over the element to see the time. I think the job list would be way more intuitive to use when the dates are rendered right away (most people will probably not know about the hovering).

This PR extends the label of these items.

Best, Moritz
Technical University of Munich

<img width="259" alt="Screenshot 2023-06-20 at 09 52 37" src="https://github.com/ICOS-Carbon-Portal/stiltweb/assets/29046316/c2aad140-52f9-401c-8adf-4286fce7cecb">
