### PR TITLE
Improve frontend layout

### DIFF
--- a/src/main/js/common/components/Select.jsx
+++ b/src/main/js/common/components/Select.jsx
@@ -23,7 +23,12 @@ export default function(props){
 	const stringValues = [props.infoTxt].concat(availableValues.map(toStringValue));
 	const current = toStringValue(props.value) || props.infoTxt;
 
-	return <select value={current} className="form-control" onChange={changeHandler} {...props.options}>{
+	return <select
+		value={current}
+		className={`form-control ${props.className ? props.className : ""}`}
+		style={props.style ? props.style : {}}
+		onChange={changeHandler}
+		{...props.options}>{
 		stringValues.map(sv => <option key={sv} value={sv}>{sv}</option>)
 	}</select>;
 }

--- a/src/main/js/common/customStyles.css
+++ b/src/main/js/common/customStyles.css
@@ -2,6 +2,3 @@ svg {
     /* reset style from _reboot (bootstrap) */
     vertical-align: baseline;
 }
-label {
-    font-weight: bold;
-}

--- a/src/main/js/viewer/components/ControlPanel.jsx
+++ b/src/main/js/viewer/components/ControlPanel.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 
 import config from '../config';
 

--- a/src/main/js/viewer/components/ControlPanel.jsx
+++ b/src/main/js/viewer/components/ControlPanel.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 
 import config from '../config';
 
@@ -10,11 +10,14 @@ import StationAndYearSelector from './StationAndYearSelector.jsx';
 
 export default props =>
 		<div className="row">
-			<div className="col-md-6" style={{paddingRight:0}}>
+			<div className="col-md-6 pe-0">
+			
+				<h2 className="visually-hidden">Station selection map</h2>
 				<StationSelectingMap {...props} />
 			</div>
-			<div className="col-md-6" style={{paddingLeft: 0}}>
-				<ul className="list-group" style={{marginBottom:0}}>
+			<div className="col-md-6 ps-0">
+				<h2 className="visually-hidden">Configuration settings</h2>
+				<ul className="list-group rounded-0 mb-0">
 					{config.viewerScope
 						? <ViewerScopeDisplay {...config.viewerScope} />
 						: <StationAndYearSelector {...props} />
@@ -45,7 +48,7 @@ const GasSelector = ({selectGas, gas, selectedGas}) => {
 			onChange={() => selectGas(gasVar)}
 			checked={selectedGas === gasVar}
 		/>
-		<label className="form-check-label" htmlFor={gasVar + "radio"}>{gas}</label>
+		<label className="form-check-label fw-bold" htmlFor={gasVar + "radio"}>{gas}</label>
 	</div>
 }
 
@@ -76,7 +79,7 @@ const ViewerScopeDisplay = props => <li className="list-group-item">
 
 const AxisControlPrimary = props => {
 	return <div>
-		<strong>{props.title}:</strong>
+		<h3 className="h6 text-black fw-bold">{props.title}:</h3>
 		<FanOutComponents fanOuts={props.components} {...props} />
 	</div>;
 };
@@ -94,10 +97,10 @@ const FanOutComponents = props => {
 const AxisControlSecondary = props => {
 	return (
 		<div>
-			<strong>{props.title}:</strong>
+			<h3 className="h6 text-black fw-bold">{props.title}:</h3>
 			{Object.keys(props.components).map((label, i) =>
 				<div key={'group' + i}>
-					<div style={{textDecoration:'underline'}}>{label}</div>
+					<div className="text-decoration-underline">{label}</div>
 					<FanOutComponents fanOuts={props.components[label]} {...props} />
 				</div>
 			)}
@@ -124,8 +127,11 @@ const StiltComponentSelector = ({label, comment, disabled, updateVisibility, opt
 			onChange={visibilityChangeHandler}
 			style={style}
 			disabled={disabled}
+			id={label.replaceAll(".", "-")}
 		/>
-		{label}
+		<label htmlFor={label.replaceAll(".", "-")}>
+			{label}
+		</label>
 	</div>
 };
 
@@ -140,37 +146,41 @@ const MovieControl = props => {
 	const playClass = "fas fa-" + (props.playingMovie ? 'pause' : 'play');
 	const playTitle = props.playingMovie ? 'Pause playback' : 'Play';
 
-	return <div className="row">
-		<div className="col-md-2">
-			<strong>Playback</strong>
-		</div>
-		<div className="col-md-4">
-			<div className="btn-group" style={{minWidth: 120}}>
-				<button title="To previous footprint" type="button" className="btn btn-outline-secondary" onClick={toPrevious} disabled={navDisabled}>
-					<i className="fas fa-chevron-left" />
-				</button>
-				<button title={playTitle} type="button" className="btn btn-outline-secondary" onClick={props.pushPlay} disabled={!props.footprint}>
-					<i className={playClass} />
-				</button>
-				<button  title="To next footprint" type="button" className="btn btn-outline-secondary" onClick={toNext} disabled={navDisabled}>
-				<i className="fas fa-chevron-right" />
-				</button>
+	return <Fragment>
+		<div className="row my-1 justify-content-between align-items-center">
+			<div className="col-auto me-auto">
+				<strong>Playback</strong>
+			</div>
+			<div className="col-auto ms-auto">
+				<div className="btn-group" style={{minWidth: 120}}>
+					<button title="To previous footprint" type="button" className="btn btn-outline-secondary" onClick={toPrevious} disabled={navDisabled}>
+						<i className="fas fa-chevron-left" />
+					</button>
+					<button title={playTitle} type="button" className="btn btn-outline-secondary" onClick={props.pushPlay} disabled={!props.footprint}>
+						<i className={playClass} />
+					</button>
+					<button  title="To next footprint" type="button" className="btn btn-outline-secondary" onClick={toNext} disabled={navDisabled}>
+					<i className="fas fa-chevron-right" />
+					</button>
+				</div>
 			</div>
 		</div>
-		<div className="col-md-2">
-			<strong>Playback speed</strong>
+		<div className="row my-1 justify-content-between align-items-center">
+			<div className="col-auto me-auto">
+				<strong>Playback speed</strong>
+			</div>
+			<div className="col-auto ms-auto">
+				<Select
+					selectValue={props.setDelay}
+					infoTxt="Select playback speed"
+					availableValues={delayValues}
+					value={props.movieDelay}
+					presenter={delayPresenter}
+					options={{disabled: !props.footprint}}
+				/>
+			</div>
 		</div>
-		<div className="col-md-4">
-			<Select
-				selectValue={props.setDelay}
-				infoTxt="Select playback speed"
-				availableValues={delayValues}
-				value={props.movieDelay}
-				presenter={delayPresenter}
-				options={{disabled: !props.footprint}}
-			/>
-		</div>
-	</div>;
+	</Fragment>;
 };
 
 const delayValues = [0, 50, 100, 200, 500, 1000, 3000];

--- a/src/main/js/viewer/components/ControlPanel.jsx
+++ b/src/main/js/viewer/components/ControlPanel.jsx
@@ -146,41 +146,39 @@ const MovieControl = props => {
 	const playClass = "fas fa-" + (props.playingMovie ? 'pause' : 'play');
 	const playTitle = props.playingMovie ? 'Pause playback' : 'Play';
 
-	return <Fragment>
-		<div className="row my-1 justify-content-between align-items-center">
-			<div className="col-auto me-auto">
-				<strong>Playback</strong>
+	return <div className="row">
+		<div className="d-flex col my-1 justify-content-between align-items-center">
+			<div className="me-auto fw-bold pe-1">
+				Playback
 			</div>
-			<div className="col-auto ms-auto">
-				<div className="btn-group" style={{minWidth: 120}}>
-					<button title="To previous footprint" type="button" className="btn btn-outline-secondary" onClick={toPrevious} disabled={navDisabled}>
-						<i className="fas fa-chevron-left" />
-					</button>
-					<button title={playTitle} type="button" className="btn btn-outline-secondary" onClick={props.pushPlay} disabled={!props.footprint}>
-						<i className={playClass} />
-					</button>
-					<button  title="To next footprint" type="button" className="btn btn-outline-secondary" onClick={toNext} disabled={navDisabled}>
-					<i className="fas fa-chevron-right" />
-					</button>
-				</div>
+			<div className="ms-auto btn-group" style={{minWidth: 120}}>
+				<button title="To previous footprint" type="button" className="btn btn-outline-secondary" onClick={toPrevious} disabled={navDisabled}>
+					<i className="fas fa-chevron-left" />
+				</button>
+				<button title={playTitle} type="button" className="btn btn-outline-secondary" onClick={props.pushPlay} disabled={!props.footprint}>
+					<i className={playClass} />
+				</button>
+				<button  title="To next footprint" type="button" className="btn btn-outline-secondary" onClick={toNext} disabled={navDisabled}>
+				<i className="fas fa-chevron-right" />
+				</button>
 			</div>
 		</div>
-		<div className="row my-1 justify-content-between align-items-center">
-			<div className="col-auto me-auto">
-				<strong>Playback speed</strong>
+		<div className="d-flex col my-1 justify-content-between align-items-center">
+			<div className="me-auto fw-bold pe-1">
+				Playback speed
 			</div>
-			<div className="col-auto ms-auto">
-				<Select
-					selectValue={props.setDelay}
-					infoTxt="Select playback speed"
-					availableValues={delayValues}
-					value={props.movieDelay}
-					presenter={delayPresenter}
-					options={{disabled: !props.footprint}}
-				/>
-			</div>
+			<Select
+				selectValue={props.setDelay}
+				infoTxt="Select playback speed"
+				availableValues={delayValues}
+				value={props.movieDelay}
+				presenter={delayPresenter}
+				options={{disabled: !props.footprint}}
+				className="ms-auto w-auto"
+				style={{minWidth: "100px"}}
+			/>
 		</div>
-	</Fragment>;
+	</div>;
 };
 
 const delayValues = [0, 50, 100, 200, 500, 1000, 3000];

--- a/src/main/js/viewer/components/Dropdown.jsx
+++ b/src/main/js/viewer/components/Dropdown.jsx
@@ -56,11 +56,10 @@ export default class Dropdown extends Component{
 		const selectOptions = availableValues.map(v => toStringValue(v, props.presenter));
 		const buttonLbl = toStringValue(props.selectedValue, props.presenter) || props.buttonLbl;
 		const selectedIsICOS = props.selectedValue ? props.selectedValue.isICOS : false;
-		const rootStyle = Object.assign({display: 'inline-block'}, props.style);
 		const menuCls = dropdownOpen ? 'dropdown-menu overflow-scroll show' : 'dropdown-menu overflow-scroll';
 
 		return (
-			<span ref={div => this.node = div} className="dropdown" style={rootStyle}>{
+			<div ref={div => this.node = div} className="dropdown" style={props.style}>{
 				<Button
 					clickAction={this.onDropdownClick.bind(this)}
 					buttonLbl={buttonLbl}
@@ -81,7 +80,7 @@ export default class Dropdown extends Component{
 							</li>
 						)
 					}</ul>
-			</span>
+			</div>
 		);
 	}
 }
@@ -112,7 +111,7 @@ const StationMarker = ({isICOS, showSpace = true}) => {
 
 const Button = ({ clickAction, isICOS, buttonLbl = 'Select option' }) => {
 	return (
-		<button className="btn dropdown-toggle bg-white text-dark" style={{borderColor:'#ced4da'}} onClick={clickAction}>
+		<button className="btn dropdown-toggle bg-white text-dark overflow-hidden w-100" style={{borderColor:'#ced4da'}} onClick={clickAction}>
 			<StationMarker isICOS={isICOS} showSpace={false} /><span>{buttonLbl}</span> <span className="caret" />
 		</button>
 	);

--- a/src/main/js/viewer/components/StationAndYearSelector.jsx
+++ b/src/main/js/viewer/components/StationAndYearSelector.jsx
@@ -32,8 +32,8 @@ export default function(props){
 				}
 			</div>
 		</div>
-		<div className="row">
-			<div className="col-md-7">
+		<div className="row justify-content-between">
+			<div className="col-auto my-1">
 				<Dropdown
 					buttonLbl="Select station here or on the map"
 					presenter={station => station ? `${station.id} (${station.name}, ${station.alt} m)` : station}
@@ -43,7 +43,7 @@ export default function(props){
 					sort={true}
 				/>
 			</div>
-			<div className="col-md-5">
+			<div className="col-auto my-1">
 				<Select
 					selectValue={year => selectYear(yearLookup(year))}
 					infoTxt={yearsDisabled ? "Select station first" : "Select year"}

--- a/src/main/js/viewer/containers/App.jsx
+++ b/src/main/js/viewer/containers/App.jsx
@@ -42,24 +42,25 @@ class App extends Component {
 			<div>
 				<AnimatedToasters toasterData={this.props.toasterData} autoCloseDelay={5000} />
 
-				<div className="page-header">
-					<h1>
+				<div className="row page-header justify-content-between align-items-center">
+					<h1 className="col-auto">
 						{title}
-						<span style={{float:'right'}}>
-							<ResultsControl {...resControlProps}/>
-							<a className="btn btn-primary text-white" href="/worker/" target="_blank">
-								<i className="fas fa-calculator"/> STILT worker
-							</a>
-							<a className="btn btn-info text-white" href="https://www.icos-cp.eu/about-stilt-viewer" target="_blank">
-								<i className="fas fa-question-circle" /> Help
-							</a>
-						</span>
 					</h1>
+					<div className="col-auto">
+						<ResultsControl {...resControlProps}/>
+						<a className="btn btn-primary text-white mb-1" href="/worker/" target="_blank">
+							<i className="fas fa-calculator"/> STILT calculation
+						</a>
+						<a className="btn btn-info text-white" href="https://www.icos-cp.eu/about-stilt-viewer" target="_blank">
+							<i className="fas fa-question-circle" /> Help
+						</a>
+					</div>
 				</div>
 				<div className="row" style={{marginTop}}>
-
+				
+					<h2 className="visually-hidden">Footprint map</h2>
 					<div className="col-md-4" style={{paddingRight:0}}>
-						<ul className="list-group">
+						<ul className="list-group rounded-0">
 							<li className="list-group-item" style={{padding: 0}}>
 								{showSpinner ? <Spinner /> : null}
 								<FootprintContainer />
@@ -71,12 +72,14 @@ class App extends Component {
 					</div>
 
 					<div className="col-md-8" style={{paddingLeft:0}}>
+					<h2 className="visually-hidden">Footprint map</h2>
 						<ControlPanelContainer />
 					</div>
 
 				</div>
 
 				<div className="row" style={{marginTop}}>
+					<h2 className="visually-hidden">Concentration time series graph</h2>
 					<div className="col-md-12">
 						<GraphsContainer />
 					</div>

--- a/src/main/js/viewer/models/formatting.js
+++ b/src/main/js/viewer/models/formatting.js
@@ -5,6 +5,6 @@ export function pad2(num){
 
 export function formatDate(millis){
 	const d = new Date(millis);
-	return `${d.getUTCFullYear()}-${pad2(d.getUTCMonth() + 1)}-${pad2(d.getUTCDate())} ${pad2(d.getUTCHours())}:00`;
+	return `${d.getUTCFullYear()}-${pad2(d.getUTCMonth() + 1)}-${pad2(d.getUTCDate())} ${pad2(d.getUTCHours())}:${pad2(d.getUTCMinutes())}`;
 }
 

--- a/src/main/js/worker/containers/App.jsx
+++ b/src/main/js/worker/containers/App.jsx
@@ -51,19 +51,17 @@ class App extends Component {
 				maxWidth={400}
 			/>
 
-			<div className="row">
-				<div className="page-header mb-3">
-						<h1>
-							STILT calculation service <span className="fs-3 text-secondary">{subtitle}</span>
-							<span style={{float:'right'}}>
-								<a className="btn btn-primary text-white" href="/viewer/" target="_blank">
-									<i className="fas fa-search"/> STILT viewer
-								</a>
-								<a className="btn btn-info text-white" href="https://www.icos-cp.eu/about-stilt-calculator" target="_blank">
-									<i className="fas fa-question-circle" /> Help
-								</a>
-							</span>
-						</h1>
+			<div className="row page-header justify-content-between align-items-center mb-3">
+				<h1 className="col-auto">
+					STILT calculation service <span className="fs-3 text-secondary">{subtitle}</span>
+				</h1>
+				<div className="col-auto">
+					<a className="btn btn-primary text-white mb-1" href="/viewer/" target="_blank">
+						<i className="fas fa-search"/> STILT viewer
+					</a>
+					<a className="btn btn-info text-white" href="https://www.icos-cp.eu/about-stilt-calculator" target="_blank">
+						<i className="fas fa-question-circle" /> Help
+					</a>
 				</div>
 			</div>
 

--- a/src/main/twirl/views/LoginPage.scala.html
+++ b/src/main/twirl/views/LoginPage.scala.html
@@ -2,7 +2,7 @@
 @import se.lu.nateko.cp.stiltweb.AtmoAccessConfig
 
 @(authConf: PublicAuthConfig, atmoConf: AtmoAccessConfig)
-@AtmoAccessPage("Request access to ICOS footprint services"){
+@AtmoAccessPage("STILT Services - Log in through ATMO-ACCESS"){
 	<script>
 		function atmoAccessLoginUrl(targetLastSegment){
 			const cliendId = "@{atmoConf.ssoClientId}"

--- a/src/main/twirl/views/LoginPage.scala.html
+++ b/src/main/twirl/views/LoginPage.scala.html
@@ -35,35 +35,46 @@
 	<h1 class="text-center">STILT station footprint calculation and viewing services</h2>
 
 	<p class="text-center text-muted">
-		The services are provided by ICOS Carbon Portal in the context of ATMO-ACCESS project.
-		Therefore an ATMO-ACCESS login is required to use the services.
+		These services are provided by ICOS Carbon Portal in the context of ATMO-ACCESS project;
+		therefore, an ATMO-ACCESS login is required to use these services.
 	</p>
 
 	<div class="row g-4 py-5 row-cols-1 row-cols-lg-4 justify-content-center">
 
 		<div class="card" >
 			<div class="card-body text-secondary">
-				<h5 class="card-title"><i class="fas fa-rocket stilt-action"></i> STILT Model Run</h5>
-				<p class="card-text">Login and proceed to STILT model run</p>
+				<h2 class="h5 card-title d-flex align-items-center">
+					<i class="fas fa-calculator stilt-action me-2"></i>
+					<span>STILT Calculation Service</span>
+				</h2>
+				<p class="card-text">Log in and go to the STILT calculation service</p>
 				<div class="inner"><a id="stiltWorkerLink" href="" class="btn btn-info" role="button">Log in</a></div>
 			</div>
 		</div>
 
 		<div class="card" >
 			<div class="card-body text-secondary">
-				<h5 class="card-title"><i class="fas fa-search stilt-action"></i> STILT Products and Information</h5>
-				<p class="card-text">Login and proceed to STILT results viewer</p>
+				<h2 class="h5 card-title d-flex align-items-center">
+					<i class="fas fa-search stilt-action me-2"></i>
+					<span>STILT Results Viewer</span>
+				</h2>
+				<p class="card-text">Log in and go to the STILT results viewer</p>
 				<div class="inner"><a id="stiltViewerLink" href="" class="btn btn-info" role="button">Log in</a></div>
 			</div>
 		</div>
 
 		<div class="card">
 			<div class="card-body text-secondary">
-				<h5 class="card-title"><i class="fas fa-question-circle stilt-action"></i> Support</h5>
-				<p class="card-text">Do you have questions regarding STILT model runner or results viewer?</p>
+				<h2 class="h5 card-title d-flex align-items-center">
+					<i class="fas fa-question-circle stilt-action me-2"></i>
+					<span>Documentation and Support</span>
+				</h2>
+				<p class="card-text">Do you have questions regarding STILT calculation service or results viewer?</p>
 				<div class="inner">
-					<a href="https://www.icos-cp.eu/about-stilt-calculator" class="btn btn-info" role="button">Runner support</a>
-					<a href="https://www.icos-cp.eu/about-stilt-viewer" class="btn btn-info" role="button">Viewer support</a>
+					<a href="https://www.icos-cp.eu/about-stilt-calculator" class="btn btn-info mb-1" role="button">
+						<i class="fas fa-calculator"></i> Calculation help</a>
+					<a href="https://www.icos-cp.eu/about-stilt-viewer" class="btn btn-info mb-1" role="button">
+						<i class="fas fa-search"></i> Viewer help</a>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Accessibility, language, clarity, consistency, and layout fixes for the front-end, especially the results viewer.

## Accessibility
- Add visually hidden `h2` elements and convert some bold statements to `h3` elements.
- Remove buttons from `h1` to independent container, so` h1` is only heading text.
- Fix headings on log-in page.
- Ensure checkboxes in results viewer have labels, which are appropriately referencing checkbox.

## Layout and code improvement
- Fix display at intermediate widths to ensure content does not overlap.
- Change `span` tags to `div` tags when `span` tags were inappropriate. 
- Abstract inline styling to Bootstrap classes where possible.

## Consistency
- Fix border styling to ensure square borders and rounded borders are not appearing in same space.
- Fix time formatting to display accurate timestamps for half-hourly data.
- Use "STILT Calculation Service" instead of model runner/worker, where applicable.
- Update log in page to reflect terminology and accurate `title` element.