### PR TITLE
Upgrade to scala 3.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,10 @@
-ThisBuild / scalaVersion := "3.3.3"
+ThisBuild / scalaVersion := "3.8.2"
 
 Global / cancelable := true
 
 lazy val commonSettings = Seq(
 	organization := "se.lu.nateko.cp",
 	scalacOptions ++= Seq(
-		"-Xtarget:11",
 		"-encoding", "UTF-8",
 		"-unchecked",
 		"-feature",
@@ -15,10 +14,10 @@ lazy val commonSettings = Seq(
 	)
 )
 
-val akkaVersion = "2.6.20"
+val akkaVersion     = "2.6.21"
 val akkaHttpVersion = "10.2.10"
 
-val scalaTest = "org.scalatest" %% "scalatest" % "3.2.10" % "test"
+val scalaTest = "org.scalatest" %% "scalatest" % "3.2.19" % "test"
 
 lazy val stiltcluster = (project in file("stiltcluster"))
 	.settings(commonSettings: _*)
@@ -91,7 +90,7 @@ lazy val stiltweb = (project in file("."))
 		Test / unmanagedResources := {
 			val folder = (Test / unmanagedResourceDirectories).value
 			folder.flatMap{dir =>
-				import scala.collection.JavaConverters._
+				import scala.jdk.CollectionConverters.*
 				java.nio.file.Files.walk(dir.toPath).iterator.asScala.map(_.toFile)
 			}
 		},

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,7 @@ var source = require('vinyl-source-stream');
 var babelify = require('babelify');
 const { watch, dest, series, parallel } = require('gulp');
 
-var SCALA_VERSION = 'scala-3.3.3';
+var SCALA_VERSION = 'scala-3.8.2';
 var PROD = 'production'
 
 function applyProd() {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.0
+sbt.version=1.12.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,4 @@ addSbtPlugin("io.spray" % "sbt-revolver" % "0.10.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-twirl" % "1.6.0-RC2")
 
-addSbtPlugin("se.lu.nateko.cp" % "icoscp-sbt-deploy" % "0.3.2")
+addSbtPlugin("se.lu.nateko.cp" % "icoscp-sbt-deploy" % "0.4.1")

--- a/src/main/scala/se/lu/nateko/cp/stiltweb/Main.scala
+++ b/src/main/scala/se/lu/nateko/cp/stiltweb/Main.scala
@@ -12,13 +12,13 @@ import scala.util.{ Failure, Success }
 import se.lu.nateko.cp.stiltcluster.StiltClusterApi
 import scala.concurrent.ExecutionContext
 
-object Main extends App {
+@main def main(): Unit =
 
 	val cluster = new StiltClusterApi
 
 	implicit val system: ActorSystem = ActorSystem("stiltweb")
 	system.log
-	implicit val dispatcher:ExecutionContext = system.dispatcher
+	implicit val dispatcher: ExecutionContext = system.dispatcher
 
 	val config = ConfigReader.default
 
@@ -45,13 +45,11 @@ object Main extends App {
 					val doneFuture = binding.unbind()
 						.flatMap{
 							_ => system.terminate()
-						}(ctxt)
+						}(using ctxt)
 						.flatMap{
 							_ => cluster.terminate()
-						}(ctxt)
+						}(using ctxt)
 					Await.result(doneFuture, 3.seconds)
 				}
 				println(binding)
 		}
-
-}

--- a/src/main/scala/se/lu/nateko/cp/stiltweb/MainRoute.scala
+++ b/src/main/scala/se/lu/nateko/cp/stiltweb/MainRoute.scala
@@ -51,7 +51,8 @@ class MainRoute(config: StiltWebConfig, cluster: StiltClusterApi):
 	given [T: RootJsonWriter]: ToEntityMarshaller[T] = SprayJsonSupport.sprayJsonMarshaller
 
 	val resultBatchSpec: Directive1[ResultBatch] =
-		parameters("stationId", "fromDate".as[LocalDate], "toDate".as[LocalDate]).as(ResultBatch.apply _).or:
+		parameters("stationId", "fromDate".as[LocalDate], "toDate".as[LocalDate])
+			.as((stationId, fromDate, toDate) => ResultBatch(stationId, fromDate, toDate)).or:
 			complete(StatusCodes.BadRequest -> "Expected 'stationId', 'fromDate', and 'toDate' URL parameters")
 
 	def route: Route = pathPrefix("viewer"){
@@ -202,7 +203,7 @@ class MainRoute(config: StiltWebConfig, cluster: StiltClusterApi):
 		if resp.status.isFailure then resp else
 			val re = resp.entity.transformDataBytes(Flow[ByteString].watchTermination(){
 				case (mat, fut) =>
-					fut.onComplete{case _ => cb()}(cluster.ioDispatcher)
+					fut.onComplete{case _ => cb()}(using cluster.ioDispatcher)
 					mat
 			})
 			resp.withEntity(re)

--- a/src/main/scala/se/lu/nateko/cp/stiltweb/StiltResultsPresenter.scala
+++ b/src/main/scala/se/lu/nateko/cp/stiltweb/StiltResultsPresenter.scala
@@ -330,7 +330,7 @@ object StiltResultsPresenter:
 	private def toRelResPath(path: Path, relTo: Path): ResultRelPath = relTo.relativize(path).toString
 	val StiltResRelPath: PathMatcher1[ResultRelPath] = RemainingPath.map(_.toString)
 
-	private[this] val numFormat =
+	private val numFormat =
 		val nf = NumberFormat.getNumberInstance(Locale.ROOT)
 		nf.setGroupingUsed(false)
 		nf

--- a/src/main/scala/se/lu/nateko/cp/stiltweb/marshalling/StiltJsonSupport.scala
+++ b/src/main/scala/se/lu/nateko/cp/stiltweb/marshalling/StiltJsonSupport.scala
@@ -29,7 +29,7 @@ object StiltJsonSupport {
 		private val simple: JsonFormat[StiltStationInfo] = jsonFormat5(StiltStationInfo.apply)
 
 		def write(si: StiltStationInfo): JsValue = {
-			val self = si.toJson(simple).asJsObject
+			val self = si.toJson(using simple).asJsObject
 			val ids = si.id.toJson.asJsObject
 			JsObject(self.fields ++ ids.fields)
 		}

--- a/src/main/scala/se/lu/nateko/cp/stiltweb/state/JobState.scala
+++ b/src/main/scala/se/lu/nateko/cp/stiltweb/state/JobState.scala
@@ -12,9 +12,9 @@ import java.time.Instant
 class JobState(val job: Job, nSlotsTotal: Int, initWork: Seq[StiltSlot]){
 
 	val initRemainingSlots = initWork.size
-	private[this] val slotz = Set(initWork: _*)
-	private[this] val failures = Buffer.empty[SlotFailure]
-	private[this] var doneTime: Option[Instant] = None
+	private val slotz = Set(initWork*)
+	private val failures = Buffer.empty[SlotFailure]
+	private var doneTime: Option[Instant] = None
 
 	def slots = slotz.toSeq
 	def nSlots = slotz.size

--- a/src/main/scala/se/lu/nateko/cp/stiltweb/state/State.scala
+++ b/src/main/scala/se/lu/nateko/cp/stiltweb/state/State.scala
@@ -78,7 +78,7 @@ class State(archiver: Archiver):
 	}
 
 	def cancelJob(id: JobId): Option[Job] = jobs.remove(id).map{jstate =>
-		val toRemove = Set(jstate.slots: _*)
+		val toRemove = Set(jstate.slots*)
 		//the following will remove only one occurrence of slot per queue
 		//this is desired because same slot may be repeated due to overlapping jobs
 		slots.dequeueAll(toRemove.remove)

--- a/src/main/scala/se/lu/nateko/cp/stiltweb/state/WorkmasterState.scala
+++ b/src/main/scala/se/lu/nateko/cp/stiltweb/state/WorkmasterState.scala
@@ -64,7 +64,7 @@ object WorkmasterState{
 	val RequestAgeLimit = 5
 	type RequestId = Long
 
-	private[this] var reqId: RequestId = 0
+	private var reqId: RequestId = 0
 
 	def getRequestId: RequestId = {
 		reqId += 1

--- a/stiltcluster/src/main/scala/se/lu/nateko/cp/stiltcluster/WorkMasterApp.scala
+++ b/stiltcluster/src/main/scala/se/lu/nateko/cp/stiltcluster/WorkMasterApp.scala
@@ -1,41 +1,43 @@
 package se.lu.nateko.cp.stiltcluster
 
 import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
 import scala.util.Try
 
 import akka.actor.ActorSystem
 import akka.pattern.gracefulStop
 
-object WorkMasterApp extends App {
+object WorkMasterApp {
 
-	val conf = ConfigLoader.workerNode()
-	val system = ActorSystem("WorkMaster", conf)
+	def main(args: Array[String]): Unit = {
+		val conf = ConfigLoader.workerNode()
+		val system = ActorSystem("WorkMaster", conf)
 
-	private val coresForStilt: Int = {
+		val coresForStilt: Int = {
 
-		val maxAllowedTry = Try{
-			val maxVal = conf.getInt("stiltcluster.maxCores")
-			if(maxVal <= 0) Int.MaxValue
-			else maxVal
+			val maxAllowedTry = Try{
+				val maxVal = conf.getInt("stiltcluster.maxCores")
+				if(maxVal <= 0) Int.MaxValue
+				else maxVal
+			}
+
+			Math.min(
+				maxAllowedTry.getOrElse(Int.MaxValue),
+				Runtime.getRuntime.availableProcessors
+			)
 		}
 
-		Math.min(
-			maxAllowedTry.getOrElse(Int.MaxValue),
-			Runtime.getRuntime.availableProcessors
+		val wm = system.actorOf(
+			WorkMaster.props(coresForStilt, conf.getString("stiltcluster.receptionistAddress")),
+			name = "workmaster"
 		)
+
+		sys.addShutdownHook{
+			val done = gracefulStop(wm, 2.seconds, WorkMaster.Stop).transformWith{
+				_ => system.terminate()
+			}(using global)
+			Await.ready(done, 3.seconds)
+		}
 	}
-
-	val wm = system.actorOf(
-		WorkMaster.props(coresForStilt, conf.getString("stiltcluster.receptionistAddress")),
-		name = "workmaster"
-	)
-
-	sys.addShutdownHook{
-		val done = gracefulStop(wm, 2.seconds, WorkMaster.Stop).transformWith{
-			_ => system.terminate()
-		}(scala.concurrent.ExecutionContext.Implicits.global)
-		Await.ready(done, 3.seconds)
-	}
-
 }


### PR DESCRIPTION
The changes are hopefully straightforward and will work well. 
The main risk is that I see is that we are still using Akka 2.6 which requires Scala 2 cross compilation. I'll push another PR to upgrade to latest version of Pekko since it seems like it would be best to switch to it.