### PR TITLE
Ensure toast for login appears only once

### DIFF
--- a/src/main/js/worker/reducer.js
+++ b/src/main/js/worker/reducer.js
@@ -3,7 +3,7 @@ import {MAP_VIEW, DASHBOARD_VIEW, FETCHED_MONTHS} from './actions';
 
 import AvailableMonths from './models/AvailableMonths';
 import {copyprops} from 'icos-cp-utils';
-import {TOAST_ERROR, TOAST_INFO, ToasterData} from 'icos-cp-toaster';
+import {TOAST_ERROR, ToasterData} from 'icos-cp-toaster';
 import { initJob } from './store';
 import config from './config'
 
@@ -145,7 +145,6 @@ export function withFeedbackToUser(state){
 	if(state.currUser && !state.currUser.email){
 		const msg = 'You must log in (USE SEPARATE BROWSER TAB) to submit a STILT job';
 		jobSubmissionObstacles.push(msg)
-		toasterData = new ToasterData(TOAST_INFO, msg)
 	}
 	return Object.assign({}, state, {
 		jobSubmissionObstacles,


### PR DESCRIPTION
Removes the `ToasterData` creation within the reducer. Instead, continues to use `jobSubmissionObstacles` to populate the error message in-line and disable submit button, while displaying a single toast alert related to the log-in requirement via the existing `displayLoginInfo` function in `App.jsx`